### PR TITLE
feat(branding): add subtle Context Sheriff labels

### DIFF
--- a/codex-rs/README.md
+++ b/codex-rs/README.md
@@ -1,8 +1,18 @@
 # Codex CLI (Rust Implementation)
 
+## codex-context-sheriff fork
+
+This repository is a fork of the open source Codex CLI focused on **Context Sheriff** UX improvements: better observability and guardrails around compaction and working-tree drift.
+
+If you want to learn more about the fork, start with `docs/context-sheriff.md`.
+
 We provide Codex CLI as a standalone, native executable to ensure a zero-dependency install.
 
 ## Installing Codex
+
+Note: this fork is not distributed via `npm`/Homebrew releases. To use `codex-context-sheriff` today, clone the repo and build from source.
+
+### Upstream Codex CLI
 
 Today, the easiest way to install Codex is via `npm`:
 
@@ -12,6 +22,15 @@ codex
 ```
 
 You can also install via Homebrew (`brew install --cask codex`) or download a platform-specific release directly from our [GitHub Releases](https://github.com/openai/codex/releases).
+
+### Build this fork from source
+
+```shell
+git clone https://github.com/marcohefti/codex-context-sheriff
+cd codex-context-sheriff/codex-rs
+cargo build --release
+./target/release/codex --help
+```
 
 ## Documentation quickstart
 

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -52,6 +52,8 @@ use codex_core::features::is_known_feature_key;
 #[clap(
     author,
     version,
+    about = "Codex CLI (codex-context-sheriff fork)",
+    long_about = "Codex CLI (codex-context-sheriff fork)\n\nThis fork adds subtle UI-only observability + guardrail improvements while keeping Codex behavior intact.",
     // If a sub‑command is given, ignore requirements of the default args.
     subcommand_negates_reqs = true,
     // The executable is sometimes invoked via a platform‑specific name like

--- a/codex-rs/docs/context-sheriff.md
+++ b/codex-rs/docs/context-sheriff.md
@@ -1,0 +1,27 @@
+# Context Sheriff (codex-context-sheriff)
+
+This repository is a fork of the open source Codex CLI.
+
+## Thesis
+
+Many reports of “model degradation” are actually **user/agent drift** after context compaction or working-tree changes that are not obvious in the UI.
+
+This fork focuses on making those boundaries observable without changing Codex core behavior.
+
+## Flagship features (Tasks 001004)
+
+- **Compaction summary is visible in the transcript** (manual + auto), so you can see what the next turn will “know”.
+- **`/compact --preview`** lets you inspect the proposed summary before applying a manual compaction.
+- **Working tree drift notice** warns (non-blocking, opt-out) when files changed outside the session.
+- **Subtle fork branding** in the TUI header and CLI about/help output.
+
+## What this fork intentionally does not change
+
+- No token dashboards.
+- No new blocking prompts.
+- No changes to tool behavior, approvals, or auto-compaction mechanics.
+
+## How to try it
+
+- Install and usage follow upstream Codex CLI docs; start at `README.md`.
+- For local development commands, use the workspace `just` recipes.

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -798,10 +798,18 @@ impl HistoryCell for SessionHeaderHistoryCell {
 
         let make_row = |spans: Vec<Span<'static>>| Line::from(spans);
 
-        // Title line rendered inside the box: ">_ OpenAI Codex (vX)"
+        let branding = if inner_width >= 52 {
+            "Codex (Context Sheriff)"
+        } else if inner_width >= 34 {
+            "Codex (CS)"
+        } else {
+            "Codex"
+        };
+
+        // Title line rendered inside the box: ">_ <branding> (vX)"
         let title_spans: Vec<Span<'static>> = vec![
             Span::from(">_ ").dim(),
-            Span::from("OpenAI Codex").bold(),
+            Span::from(branding).bold(),
             Span::from(" ").dim(),
             Span::from(format!("(v{})", self.version)).dim(),
         ];


### PR DESCRIPTION
This adds subtle, UI-only branding and reviewer-facing docs so the fork is immediately recognizable without changing Codex behavior.

Changes:

- TUI: session header shows `Codex (Context Sheriff)` with narrow-terminal fallbacks.
- CLI: `--help` / about text mentions the `codex-context-sheriff` fork.
- Docs: adds `docs/context-sheriff.md` as the canonical fork overview (thesis, features, non-goals).
- README: adds a small fork "front door" section + clarifies this fork is currently build-from-source only.

Constraints honored:

- No behavior changes (tools, compaction, approvals, auto-compaction).
- No new commands, prompts, or protocol events.